### PR TITLE
Fixes #14 - muon api to delete streams.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 all: clean target
 
 run: target
-	java -jar target/photon.jar
+	java -jar target/photon.jar -ui.port 3500
 
 run-mongo: target
-	java -jar target/photon.jar -db.backend mongo -mongodb.host localhost
+	java -jar target/photon.jar -db.backend mongo -mongodb.host localhost -ui.port 3500
 
 
 build: target

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ run-mongo: target
 
 build: target
 target:
-	$(shell cp `lein do clean, cljsbuild once, uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p'` target/photon.jar)
+	$(shell cp `lein do clean, uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p'` target/photon.jar)
 
 docker:
 	docker build . -t photon

--- a/src/photon/muon.clj
+++ b/src/photon/muon.clj
@@ -48,6 +48,11 @@
                     (api/post-event!
                      stream-manager
                      (clojure.walk/keywordize-keys ev)))}
+     {:endpoint "stream/delete"
+      :fn-process (fn [resource]
+                    (log/trace ":::: DELETING STREAM" (pr-str resource))
+                    (let [params (clojure.walk/keywordize-keys resource)]
+                      (api/delete-stream! stream-manager (:stream-name params))))}
      {:endpoint "stream-names"
       :fn-process (fn [ev]
                     (log/trace ":::: EVENTS" (pr-str ev))


### PR DESCRIPTION
This seems to correctly invoke the internal api to remove streams, but that api doesn't work when the stream name has a `/` in it ... 

I'll file another issue to investigate that.